### PR TITLE
Add customization to the information lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,30 @@ Any package manager will do.
 Plug 'mcchrish/info-window.nvim'
 ```
 
+## Configuration
+
+By default, the following information is displayed in the information window:
+
+- Buffer name
+- Buffer type
+- Buffer format
+- Number of lines
+
+But you can use `g:infowindow_lines` to control the lines that you display in
+the information window.
+
+```vim
+let g:infowindow_lines = [
+    \ " Line: " . line('.'),
+    \ " Column: " . col('.'),
+    \ " File: " . &filetype . ' - ' . &fileencoding . ' [' . &fileformat . ']',
+    ]
+```
+
+By default, the information window will disappear after 2.5 seconds. You can
+change it using `g:infowindow_timeout`. If the timeout is `0`, then it will
+not be closed automatically.
+
 <p align="center">
   <img width="934" src="https://user-images.githubusercontent.com/7200153/77721438-dce02780-7025-11ea-9f70-0540eba1fae3.png" alt="sample screenshot">
   <small>colorscheme <a href="https://github.com/pgdouyon/vim-yin-yang">yin</a></small>

--- a/autoload/infowindow.vim
+++ b/autoload/infowindow.vim
@@ -13,7 +13,7 @@ function infowindow#timer_handler(timer)
   call infowindow#destroy()
 endfunction
 
-function infowindow#setup_window(win, buf, opts)
+function s:setup_window(win, buf, opts)
   call nvim_buf_set_name(a:buf, '1_infowindow_1')
   call setwinvar(a:win, '&winhighlight', 'NormalFloat:'..'StatusLine')
   call setwinvar(a:win, '&colorcolumn', '')
@@ -56,7 +56,7 @@ function infowindow#create(lines, timeout)
   if !exists("g:infowindow_mainwindow")
     let g:infowindow_mainwindow = nvim_open_win(buf, v:false, opts)
   endif
-  call infowindow#setup_window(g:infowindow_mainwindow, buf, opts)
+  call <SID>setup_window(g:infowindow_mainwindow, buf, opts)
 
   if a:timeout > 0
     let g:infowindow_timer = timer_start(a:timeout, 'infowindow#timer_handler')

--- a/autoload/infowindow.vim
+++ b/autoload/infowindow.vim
@@ -17,6 +17,7 @@ function infowindow#setup_window(win, buf, opts)
   call nvim_buf_set_name(a:buf, '1_infowindow_1')
   call setwinvar(a:win, '&winhighlight', 'NormalFloat:'..'StatusLine')
   call setwinvar(a:win, '&colorcolumn', '')
+  call nvim_win_set_config(a:win, a:opts)
 endfunction
 
 function infowindow#create(lines, timeout)
@@ -50,7 +51,8 @@ function infowindow#create(lines, timeout)
         \ 'height': len(a:lines)
         \ }
 
-  call nvim_buf_set_lines(buf, 0, 0, v:true, a:lines)
+  let last_index = nvim_buf_line_count(buf)
+  call nvim_buf_set_lines(buf, 0, last_index, v:true, a:lines)
   if !exists("g:infowindow_mainwindow")
     let g:infowindow_mainwindow = nvim_open_win(buf, v:false, opts)
   endif

--- a/autoload/infowindow.vim
+++ b/autoload/infowindow.vim
@@ -1,34 +1,54 @@
-let g:_infobuf_1 = -1
+let g:infowindow_buffnr = -1
+let g:infowindow_loaded = 1
 
-function infowindow#toggle()
-  if (bufexists(g:_infobuf_1))
-    execute 'bdelete ' g:_infobuf_1
-    let g:_infobuf_1 = -1
-    return
+function infowindow#destroy()
+  if (bufexists(g:infowindow_buffnr))
+    execute 'bdelete ' . g:infowindow_buffnr
+    let g:infowindow_buffnr = -1
   endif
-  let cbuf = bufnr('')
-  let buffilename = bufname(cbuf)
-  let filename = ' name:   ' . (strlen(buffilename) > 0 ? buffilename : '[No Name]') . ' '
-  let filetype = ' type:   ' . (strlen(&filetype) > 0 ? &filetype : 'unknown') . ' '
-  let fileformat = ' format: ' . &fileformat . ' '
-  let numlines = ' lines:  ' . line('$') . ' '
+endfunction
+
+function infowindow#timer_handler(timer)
+  call infowindow#destroy()
+endfunction
+
+function infowindow#create(lines, timeout)
+  if (bufexists(g:infowindow_buffnr))
+    if exists("g:infowindow_timer")
+      call timer_stop(g:infowindow_timer)
+    endif
+
+    call infowindow#destroy()
+  endif
+
+  let lengths = []
+  for lines in a:lines
+    call add(lengths, strlen(lines))
+  endfor
+
   let width = min([
-        \ max([strlen(filename), strlen(filetype)]), 
+        \ max(lengths),
         \ &columns / 2
         \ ])
+
   let buf = nvim_create_buf(v:false, v:true)
-  let g:_infobuf_1 = buf
-  let opts = { 
+  let g:infowindow_buffnr = buf
+
+  let opts = {
         \ 'relative': 'editor',
         \ 'style': 'minimal',
         \ 'row': 2,
         \ 'col': &columns - (width + 4),
         \ 'width': width,
-        \ 'height': 5
+        \ 'height': len(a:lines)
         \ }
   call nvim_buf_set_name(buf, '1_infowindow_1')
-  call nvim_buf_set_lines(buf, 0, 0, v:true, [filename, filetype, fileformat, numlines])
+  call nvim_buf_set_lines(buf, 0, 0, v:true, a:lines)
   let win = nvim_open_win(buf, v:false, opts)
   call setwinvar(win, '&winhighlight', 'NormalFloat:'..'StatusLine')
   call setwinvar(win, '&colorcolumn', '')
+
+  if a:timeout > 0
+    let g:infowindow_timer = timer_start(a:timeout, 'infowindow#timer_handler')
+  endif
 endfunction

--- a/autoload/infowindow.vim
+++ b/autoload/infowindow.vim
@@ -7,6 +7,10 @@ function infowindow#destroy()
     let g:infowindow_buffnr = -1
     unlet g:infowindow_mainwindow
   endif
+  if (exists("g:infowindow_timer"))
+    call timer_stop(g:infowindow_timer)
+    unlet g:infowindow_timer
+  endif
 endfunction
 
 function infowindow#timer_handler(timer)
@@ -23,6 +27,7 @@ endfunction
 function infowindow#create(lines, timeout)
   if (bufexists(g:infowindow_buffnr) && exists("g:infowindow_timer"))
     call timer_stop(g:infowindow_timer)
+    unlet g:infowindow_timer
   endif
 
   let lengths = []

--- a/plugin/infowindow.vim
+++ b/plugin/infowindow.vim
@@ -1,1 +1,25 @@
-command! -bar -nargs=? -complete=dir InfoWindowToggle call infowindow#toggle()
+function! infowindow#create_default()
+  let lines = get(g:, 'infowindow_lines', [])
+  let timeout = get(g:, 'infowindow_timeout', 2500)
+  if len(lines) != 0
+    call infowindow#create(lines, timeout)
+    return
+  endif
+
+  let cbuf = bufnr('')
+  let buffilename = expand("%:t")
+  call add(lines,
+        \ ' name: ' . (strlen(buffilename) > 0 ? buffilename
+        \                                      : '[No Name]') . ' ')
+
+  call add(lines,
+        \ ' type: ' . (strlen(&filetype) > 0 ? &filetype : 'unknown') . ' ')
+
+  call add(lines, ' format: ' . &fileformat . ' ')
+  call add(lines, ' lines: ' . line('$') . ' ')
+
+  call infowindow#create(lines, timeout)
+endfunction
+
+command! InfoWindowShow call infowindow#create_default()
+command! InfoWindowClose call infowindow#destroy()

--- a/plugin/infowindow.vim
+++ b/plugin/infowindow.vim
@@ -1,8 +1,8 @@
-function! infowindow#create_default()
+function! infowindow#create_default(timeout)
   let lines = get(g:, 'infowindow_lines', [])
-  let timeout = get(g:, 'infowindow_timeout', 2500)
+  let duration = get(g:, 'infowindow_timeout', a:timeout)
   if len(lines) != 0
-    call infowindow#create(lines, timeout)
+    call infowindow#create(lines, duration)
     return
   endif
 
@@ -18,8 +18,18 @@ function! infowindow#create_default()
   call add(lines, ' format: ' . &fileformat . ' ')
   call add(lines, ' lines: ' . line('$') . ' ')
 
-  call infowindow#create(lines, timeout)
+  call infowindow#create(lines, duration)
 endfunction
 
-command! InfoWindowShow call infowindow#create_default()
+function! infowindow#toggle()
+    if g:infowindow_buffnr != -1
+        call infowindow#destroy()
+    else
+        call infowindow#create_default(-1)
+    endif
+endfunction
+
+command! InfoWindowShow call infowindow#create_default(2500)
 command! InfoWindowClose call infowindow#destroy()
+
+command! InfoWindowToggle call infowindow#toggle()


### PR DESCRIPTION
I added `g:infowindow_lines` and `g:infowindow_timeout` variables to customize the information that we display in the information window. If the timeout is not a positive number then the information window will not close automatically.

It's my first time contributing to a plugin, so I'm not *that* familiar with writing plugin rules. I'd appreciate any feedback.